### PR TITLE
Upgrade to use asherah-cobhan v0.4.3 and improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.3.0] - 2022-03-22
+
+- Free up cobhan buffers after encrypt/decrypt to prevent growing heap memory
+- Use local `estimate_buffer` calculation instead of FFI call
+- Upgrade to use asherah-cobhan v0.4.3
+
 ## [0.2.0] - 2022-03-21
 
 - Implement versioning for asherah-cobhan binaries

--- a/bin/download-asherah.sh
+++ b/bin/download-asherah.sh
@@ -8,7 +8,7 @@ root=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )
 DIR=$root/lib/asherah/native
 mkdir "$DIR" 2> /dev/null || true
 
-VERSION=v0.3.1
+VERSION=v0.4.3
 
 for file in $files; do
   rm "$DIR/$file" 2> /dev/null || true

--- a/lib/asherah.rb
+++ b/lib/asherah.rb
@@ -96,7 +96,7 @@ module Asherah
       ESTIMATED_ENVELOPE_OVERHEAD +
         @intermediated_key_overhead_bytesize +
         partition_bytesize +
-        (data_bytesize + ESTIMATED_ENCRYPTION_OVERHEAD) * BASE64_OVERHEAD
+        ((data_bytesize + ESTIMATED_ENCRYPTION_OVERHEAD) * BASE64_OVERHEAD)
     end
   end
 end

--- a/lib/asherah.rb
+++ b/lib/asherah.rb
@@ -59,6 +59,8 @@ module Asherah
       Error.check_result!(result, 'EncryptToJson failed')
 
       cbuffer_to_string(output_buffer)
+    ensure
+      [partition_id_buffer, data_buffer, output_buffer].map(&:free)
     end
 
     # Decrypts a DataRowRecord in JSON format for a partition_id and returns decrypted data.
@@ -75,6 +77,8 @@ module Asherah
       Error.check_result!(result, 'DecryptFromJson failed')
 
       cbuffer_to_string(output_buffer)
+    ensure
+      [partition_id_buffer, data_buffer, output_buffer].map(&:free)
     end
 
     # Stop the Asherah instance

--- a/lib/asherah/version.rb
+++ b/lib/asherah/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Asherah
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
- Free up cobhan buffers after encrypt/decrypt to prevent growing heap memory
- Use local `estimate_buffer` calculation instead of FFI call
- Upgrade to use asherah-cobhan v0.4.3