### PR TITLE
Upgrade to use asherah-cobhan v0.4.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.10] - 2023-08-10
+
+- Upgrade to use asherah-cobhan v0.4.25
+
 ## [0.4.9] - 2023-07-05
 
 - Upgrade to use asherah-cobhan v0.4.24

--- a/ext/asherah/checksums.yml
+++ b/ext/asherah/checksums.yml
@@ -1,5 +1,5 @@
-version:                v0.4.24
-libasherah-arm64.so:    3b038116cb1bc1240e9c44cdc0a8fc57df2d721f15ed708294926bf2037fe8a0
-libasherah-x64.so:      ffeb968144db6df6edd2d3e247db09c84edc54fe24a42cd8ad6f5912e9ab7118
-libasherah-arm64.dylib: de660a21ae192baa522963cc6665092172880409c5e6fbedb741a6791d572698
-libasherah-x64.dylib:   dc9c398060a61ef4a7b00d983ffcbea917e63510006208512dcb176caa74aab6
+version:                v0.4.25
+libasherah-arm64.so:    573d4ac89dc54be952b428e4caa52f00861d67fdd94baf2deb0b37a1e40ea5d1
+libasherah-x64.so:      9a976b425edcaa27be84314414747c3d4abc22571c9ae8170f476822c2380716
+libasherah-arm64.dylib: 73f60860303af81de5f042d50ef755bbac34bae9f966d654036a259161e03f81
+libasherah-x64.dylib:   a0e0c5c69278602cd19889df9b86795baf957cdaa4635c413c81d06b59572ec4

--- a/lib/asherah/version.rb
+++ b/lib/asherah/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Asherah
-  VERSION = '0.4.9'
+  VERSION = '0.4.10'
 end


### PR DESCRIPTION
Upgrade to use asherah-cobhan v0.4.25: https://github.com/godaddy/asherah-cobhan/pull/55

https://github.com/godaddy/asherah-cobhan/releases/tag/v0.4.25