### PR TITLE
Upgrade to use asherah-cobhan v0.4.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.5.0] - 2023-10-16
+
+- Upgrade to use asherah-cobhan v0.4.30
+- Expose `test-debug-static` kms type and `test-debug-memory` metastore type to skip warnings in tests
+- Check initialized flag on setup/shutdown and raise appropriate errors
+
 ## [0.4.10] - 2023-08-10
 
 - Upgrade to use asherah-cobhan v0.4.25

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Asherah.configure do |config|
 end
 ```
 
+See [config.rb](lib/asherah/config.rb) for all evailable configuration options.
+
 Encrypt some data for a `partition_id`
 
 ```ruby

--- a/ext/asherah/checksums.yml
+++ b/ext/asherah/checksums.yml
@@ -1,5 +1,5 @@
-version:                v0.4.25
-libasherah-arm64.so:    573d4ac89dc54be952b428e4caa52f00861d67fdd94baf2deb0b37a1e40ea5d1
-libasherah-x64.so:      9a976b425edcaa27be84314414747c3d4abc22571c9ae8170f476822c2380716
-libasherah-arm64.dylib: 73f60860303af81de5f042d50ef755bbac34bae9f966d654036a259161e03f81
-libasherah-x64.dylib:   a0e0c5c69278602cd19889df9b86795baf957cdaa4635c413c81d06b59572ec4
+version:                v0.4.30
+libasherah-arm64.so:    cb0985cd8f5d2c2ceac0e874e3f5b1276a9b2145c6274f9c7ccf80ddd7a5f469
+libasherah-x64.so:      a91d0703a569941a38c3fdd6c1320904b47e3592fa9b9164f43704e5f4a1dda9
+libasherah-arm64.dylib: 8bac6d3a2a255553e7d1460f9e56a81d4ee7055e7f44f8f1a65cb6d584eabf6e
+libasherah-x64.dylib:   b264dc01ac6ac4ae6ae9dad8cab1f69ed887cca3e4ea0798ea572b444578e2c8

--- a/lib/asherah.rb
+++ b/lib/asherah.rb
@@ -45,6 +45,7 @@ module Asherah
     # @return [void]
     def configure
       raise Asherah::Error::AlreadyInitialized if @initialized
+
       config = Config.new
       yield config
       config.validate!
@@ -107,6 +108,7 @@ module Asherah
     # Stop the Asherah instance
     def shutdown
       raise Asherah::Error::NotInitialized unless @initialized
+
       Shutdown()
       @initialized = false
     end

--- a/lib/asherah.rb
+++ b/lib/asherah.rb
@@ -44,6 +44,7 @@ module Asherah
     # @yield [Config]
     # @return [void]
     def configure
+      raise Asherah::Error::AlreadyInitialized if @initialized
       config = Config.new
       yield config
       config.validate!
@@ -53,6 +54,7 @@ module Asherah
 
       result = SetupJson(config_buffer)
       Error.check_result!(result, 'SetupJson failed')
+      @initialized = true
     end
 
     # Encrypts data for a given partition_id and returns DataRowRecord in JSON format.
@@ -104,7 +106,9 @@ module Asherah
 
     # Stop the Asherah instance
     def shutdown
+      raise Asherah::Error::NotInitialized unless @initialized
       Shutdown()
+      @initialized = false
     end
 
     private

--- a/lib/asherah/config.rb
+++ b/lib/asherah/config.rb
@@ -43,8 +43,8 @@ module Asherah
       verbose: :Verbose
     }.freeze
 
-    KMS_TYPES = ['static', 'aws'].freeze
-    METASTORE_TYPES = ['rdbms', 'dynamodb', 'memory'].freeze
+    KMS_TYPES = ['static', 'aws', 'test-debug-static'].freeze
+    METASTORE_TYPES = ['rdbms', 'dynamodb', 'memory', 'test-debug-memory'].freeze
 
     attr_accessor(*MAPPING.keys)
 

--- a/lib/asherah/version.rb
+++ b/lib/asherah/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Asherah
-  VERSION = '0.4.10'
+  VERSION = '0.5.0'
 end

--- a/spec/asherah_spec.rb
+++ b/spec/asherah_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Asherah do
     lambda do |config|
       config.service_name = 'gem'
       config.product_id = 'sable'
-      config.kms = 'static'
-      config.metastore = 'memory'
+      config.kms = 'test-debug-static'
+      config.metastore = 'test-debug-memory'
     end
   }
 

--- a/spec/asherah_spec.rb
+++ b/spec/asherah_spec.rb
@@ -48,14 +48,22 @@ RSpec.describe Asherah do
     expect(Asherah.decrypt(partition_id, json)).to eq(data)
   end
 
-  it 'raises error when already configured' do
+  it 'raises error on configure when already configured' do
     expect {
       Asherah.configure do |config|
         base_config.call(config)
       end
-    }.to raise_error(Asherah::Error::AlreadyInitialized) do |e|
-      expect(e.message).to eq('SetupJson failed (-101)')
-    end
+    }.to raise_error(Asherah::Error::AlreadyInitialized)
+  end
+
+  it 'raises error on shutdown when not initialized' do
+    Asherah.shutdown # Before each work-around
+
+    expect {
+      Asherah.shutdown
+    }.to raise_error(Asherah::Error::NotInitialized)
+
+    Asherah.configure { |config| base_config.call(config) } # After each work-around
   end
 
   it 'can set environment variables' do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Asherah::Config do
           config.kms = 'other'
         end
       }.to raise_error(Asherah::Error::ConfigError) do |e|
-        expect(e.message).to eq('config.kms must be one of these: static, aws')
+        expect(e.message).to eq('config.kms must be one of these: static, aws, test-debug-static')
       end
     end
   end
@@ -79,7 +79,7 @@ RSpec.describe Asherah::Config do
           config.metastore = 'other'
         end
       }.to raise_error(Asherah::Error::ConfigError) do |e|
-        expect(e.message).to eq('config.metastore must be one of these: rdbms, dynamodb, memory')
+        expect(e.message).to eq('config.metastore must be one of these: rdbms, dynamodb, memory, test-debug-memory')
       end
     end
   end

--- a/spec/kms_spec.rb
+++ b/spec/kms_spec.rb
@@ -3,12 +3,11 @@
 RSpec.describe 'Asherah KMS integration' do
   let(:partition_id) { 'user_1' }
 
-  after :each do
-    Asherah.shutdown
-  end
-
   it 'encrypts and decrypts using KMS' do
-    kms_key_arn = ENV.fetch('KMS_KEY_ARN') { skip 'KMS_KEY_ARN env var is not set' }
+    kms_key_arn = ENV.fetch('KMS_KEY_ARN') do
+      @disable_shutdown = true
+      skip 'KMS_KEY_ARN env var is not set'
+    end
 
     Asherah.configure do |config|
       config.service_name = 'gem'
@@ -23,5 +22,7 @@ RSpec.describe 'Asherah KMS integration' do
     data = 'test'
     json = Asherah.encrypt(partition_id, data)
     expect(Asherah.decrypt(partition_id, json)).to eq(data)
+  ensure
+    Asherah.shutdown unless @disable_shutdown
   end
 end


### PR DESCRIPTION
## Summary

Upgrade to use latest asherah-cobhan binaries.

## Changelog

- Upgrade to use asherah-cobhan v0.4.30
- Expose `test-debug-static` kms type and `test-debug-memory` metastore type to skip warnings in tests
- Check initialized flag on setup/shutdown and raise appropriate errors

## Test Plan

```ruby
bundle exec rspec spec
```
