### PR TITLE
Add sql_metastore_db_type config option to support PostgresSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.5.1] - 2023-10-25
+
+- Add `sql_metastore_db_type` config option to support PostgresSQL adapter for Asherah
+- Upgrade to use asherah-cobhan v0.4.31
+
 ## [0.5.0] - 2023-10-16
 
 - Upgrade to use asherah-cobhan v0.4.30

--- a/ext/asherah/checksums.yml
+++ b/ext/asherah/checksums.yml
@@ -1,5 +1,5 @@
-version:                v0.4.30
-libasherah-arm64.so:    cb0985cd8f5d2c2ceac0e874e3f5b1276a9b2145c6274f9c7ccf80ddd7a5f469
-libasherah-x64.so:      a91d0703a569941a38c3fdd6c1320904b47e3592fa9b9164f43704e5f4a1dda9
-libasherah-arm64.dylib: 8bac6d3a2a255553e7d1460f9e56a81d4ee7055e7f44f8f1a65cb6d584eabf6e
-libasherah-x64.dylib:   b264dc01ac6ac4ae6ae9dad8cab1f69ed887cca3e4ea0798ea572b444578e2c8
+version:                v0.4.31
+libasherah-arm64.so:    5fef00afadf6557a41c4c1a6f7e6fc29670898f6b530c7f7bce7b4a2b128bec8
+libasherah-x64.so:      1ccf9dae397b4e375715e0260455108838d7f9fc85768875aeb0cfda826768c6
+libasherah-arm64.dylib: 48ed5d7e992383910c78f5e1933d6aa42bb551b26e959d4c27d41627b6a10132
+libasherah-x64.dylib:   18183fb5fb56423a5a61b162d14316c88a5f8e2b63ac004b686a29825a8f1045

--- a/lib/asherah/config.rb
+++ b/lib/asherah/config.rb
@@ -9,6 +9,7 @@ module Asherah
   # @attr [String] metastore, The type of metastore for persisting keys (rdbms, dynamodb, memory)
   # @attr [String] connection_string, The database connection string (required when metastore is rdbms)
   # @attr [String] replica_read_consistency, For Aurora sessions using write forwarding (eventual, global, session)
+  # @attr [String] sql_metastore_db_type, Which SQL driver to use (mysql, postgres, oracle), defaults to mysql
   # @attr [String] dynamo_db_endpoint, An optional endpoint URL (for dynamodb metastore)
   # @attr [String] dynamo_db_region, The AWS region for DynamoDB requests (for dynamodb metastore)
   # @attr [String] dynamo_db_table_name, The table name for DynamoDB (for dynamodb metastore)
@@ -29,6 +30,7 @@ module Asherah
       metastore: :Metastore,
       connection_string: :ConnectionString,
       replica_read_consistency: :ReplicaReadConsistency,
+      sql_metastore_db_type: :SQLMetastoreDBType,
       dynamo_db_endpoint: :DynamoDBEndpoint,
       dynamo_db_region: :DynamoDBRegion,
       dynamo_db_table_name: :DynamoDBTableName,
@@ -45,6 +47,7 @@ module Asherah
 
     KMS_TYPES = ['static', 'aws', 'test-debug-static'].freeze
     METASTORE_TYPES = ['rdbms', 'dynamodb', 'memory', 'test-debug-memory'].freeze
+    SQL_METASTORE_DB_TYPES = ['mysql', 'postgres', 'oracle'].freeze
 
     attr_accessor(*MAPPING.keys)
 
@@ -53,6 +56,7 @@ module Asherah
       validate_product_id
       validate_kms
       validate_metastore
+      validate_sql_metastore_db_type
       validate_kms_attributes
     end
 
@@ -88,6 +92,15 @@ module Asherah
       raise Error::ConfigError, 'config.metastore not set' if metastore.nil?
       unless METASTORE_TYPES.include?(metastore)
         raise Error::ConfigError, "config.metastore must be one of these: #{METASTORE_TYPES.join(', ')}"
+      end
+    end
+
+    def validate_sql_metastore_db_type
+      return if sql_metastore_db_type.nil?
+
+      unless SQL_METASTORE_DB_TYPES.include?(sql_metastore_db_type)
+        raise Error::ConfigError,
+              "config.sql_metastore_db_type must be one of these: #{SQL_METASTORE_DB_TYPES.join(', ')}"
       end
     end
 

--- a/lib/asherah/version.rb
+++ b/lib/asherah/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Asherah
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Asherah::Config do
     lambda do |config|
       config.service_name = 'gem'
       config.product_id = 'sable'
-      config.kms = 'static'
-      config.metastore = 'memory'
+      config.kms = 'test-debug-static'
+      config.metastore = 'test-debug-memory'
     end
   }
 
@@ -37,6 +37,16 @@ RSpec.describe Asherah::Config do
   end
 
   describe '#validate_kms' do
+    it 'accepts valid sql_metastore_db_type value' do
+      expect {
+        Asherah.configure do |config|
+          base_config.call(config)
+          config.kms = 'test-debug-static'
+        end
+      }.not_to raise_error
+      Asherah.shutdown
+    end
+
     it 'raises an error when kms not set' do
       expect {
         Asherah.configure do |config|
@@ -56,30 +66,6 @@ RSpec.describe Asherah::Config do
         end
       }.to raise_error(Asherah::Error::ConfigError) do |e|
         expect(e.message).to eq('config.kms must be one of these: static, aws, test-debug-static')
-      end
-    end
-  end
-
-  describe '#validate_metastore' do
-    it 'raises an error when metastore not set' do
-      expect {
-        Asherah.configure do |config|
-          base_config.call(config)
-          config.metastore = nil
-        end
-      }.to raise_error(Asherah::Error::ConfigError) do |e|
-        expect(e.message).to eq('config.metastore not set')
-      end
-    end
-
-    it 'raises an error when metastore is invalid' do
-      expect {
-        Asherah.configure do |config|
-          base_config.call(config)
-          config.metastore = 'other'
-        end
-      }.to raise_error(Asherah::Error::ConfigError) do |e|
-        expect(e.message).to eq('config.metastore must be one of these: rdbms, dynamodb, memory, test-debug-memory')
       end
     end
   end
@@ -117,6 +103,63 @@ RSpec.describe Asherah::Config do
         end
       }.to raise_error(Asherah::Error::ConfigError) do |e|
         expect(e.message).to eq('config.preferred_region not set')
+      end
+    end
+  end
+
+  describe '#validate_metastore' do
+    it 'accepts valid metastore value' do
+      expect {
+        Asherah.configure do |config|
+          base_config.call(config)
+          config.metastore = 'test-debug-memory'
+        end
+      }.not_to raise_error
+      Asherah.shutdown
+    end
+
+    it 'raises an error when metastore not set' do
+      expect {
+        Asherah.configure do |config|
+          base_config.call(config)
+          config.metastore = nil
+        end
+      }.to raise_error(Asherah::Error::ConfigError) do |e|
+        expect(e.message).to eq('config.metastore not set')
+      end
+    end
+
+    it 'raises an error when metastore is invalid' do
+      expect {
+        Asherah.configure do |config|
+          base_config.call(config)
+          config.metastore = 'other'
+        end
+      }.to raise_error(Asherah::Error::ConfigError) do |e|
+        expect(e.message).to eq('config.metastore must be one of these: rdbms, dynamodb, memory, test-debug-memory')
+      end
+    end
+  end
+
+  describe '#validate_sql_metastore_db_type' do
+    it 'accepts valid sql_metastore_db_type value' do
+      expect {
+        Asherah.configure do |config|
+          base_config.call(config)
+          config.sql_metastore_db_type = 'postgres'
+        end
+      }.not_to raise_error
+      Asherah.shutdown
+    end
+
+    it 'raises an error when sql_metastore_db_type is invalid' do
+      expect {
+        Asherah.configure do |config|
+          base_config.call(config)
+          config.sql_metastore_db_type = 'other'
+        end
+      }.to raise_error(Asherah::Error::ConfigError) do |e|
+        expect(e.message).to eq('config.sql_metastore_db_type must be one of these: mysql, postgres, oracle')
       end
     end
   end


### PR DESCRIPTION
## Summary

Add `sql_metastore_db_type` config option to support PostgresSQL adapter for Asherah:
  - https://github.com/godaddy/asherah-cobhan/pull/64
  - https://github.com/godaddy/asherah/pull/925

## Changelog

- Add `sql_metastore_db_type` config option to support PostgresSQL adapter for Asherah
- Upgrade to use asherah-cobhan v0.4.31


## Test Plan

```ruby
bundle exec rspec spec
```