### PR TITLE
Update Ruby version support to 2.7 minimum

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   NewCops: enable
   SuggestExtensions: false
   Exclude:

--- a/asherah.gemspec
+++ b/asherah.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage = 'https://github.com/godaddy/asherah-ruby'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/godaddy/asherah-ruby'


### PR DESCRIPTION
## Summary
This PR drops support for end-of-life Ruby versions (2.5 and 2.6) and sets the minimum supported version to Ruby 2.7. This is a necessary security and maintenance improvement that aligns with the project's existing CI configuration and reduces maintenance burden while eliminating security risks.

## Problem Statement
The repository currently claims to support Ruby 2.5 and 2.6, but these versions have significant issues:

- **Ruby 2.5**: Reached end-of-life in March 2021 (2+ years without security updates)
- **Ruby 2.6**: Reached end-of-life in March 2022 (1+ years without security updates)
- **CI Mismatch**: CI already tests only Ruby 2.7+ (2.7, 3.0, 3.1, 3.2)
- **RuboCop Target**: Still set to 2.5, preventing use of modern Ruby features

## Critical Security & Maintenance Risks

### 1. Security Vulnerabilities
**Unpatched CVEs in Ruby 2.5/2.6:**
- **CVE-2021-31810**: Trusting FTP PASV responses vulnerability
- **CVE-2021-32066**: StartTLS stripping vulnerability in Net::IMAP
- **CVE-2021-31799**: Command injection vulnerability in RDoc
- **CVE-2022-28739**: Buffer overrun in String-to-Float conversion
- And many more that will never be patched

### 2. Maintenance Burden
- **Testing Overhead**: Supporting EOL versions requires additional test resources
- **Feature Limitations**: Can't use Ruby 2.7+ features and improvements
- **Dependency Conflicts**: Many gems dropping Ruby 2.5/2.6 support
- **Documentation Complexity**: Need to document version-specific workarounds

### 3. Operational Risks
- **Production Vulnerabilities**: Customers using EOL Ruby versions are at risk
- **Support Complexity**: Troubleshooting issues specific to deprecated versions
- **Library Ecosystem**: Modern gems may not work with EOL Ruby versions

## Benefits of Dropping EOL Support

### 1. Security Improvements
- **Eliminate Vulnerability Surface**: No longer support versions with unpatched CVEs
- **Clear Security Baseline**: Ruby 2.7+ has active security maintenance
- **Reduced Attack Vectors**: Fewer potential security issues to track

### 2. Feature Access
- **Modern Ruby Features**: Can use pattern matching, numbered parameters, etc.
- **Performance Improvements**: Ruby 2.7+ has significant performance enhancements
- **Better Tooling**: Access to improved debugging and profiling tools

### 3. Maintenance Reduction
- **Simplified Testing**: Reduce CI complexity and test matrix size
- **Cleaner Code**: Remove version-specific workarounds and compatibility shims
- **Modern Dependencies**: Use current versions of development tools

## Changes Made

### 1. Gemspec Update
```ruby
# Before:
spec.required_ruby_version = ">= 2.5.0"

# After:  
spec.required_ruby_version = ">= 2.7.0"
```

### 2. RuboCop Configuration Update
```yaml
# Before:
TargetRubyVersion: 2.5

# After:
TargetRubyVersion: 2.7
```

### 3. CI Configuration
No changes needed - CI already tests Ruby 2.7, 3.0, 3.1, 3.2

## Breaking Change Details

### Who This Affects
Users still running Ruby 2.5 or 2.6 in production environments.

### Impact
- **Installation Failure**: `gem install asherah` will fail with clear version error
- **Bundler Resolution**: Bundle install will show clear Ruby version requirement
- **Upgrade Path**: Users must upgrade to Ruby 2.7+ to use future gem versions

### Migration Timeline
```ruby
# Current version (0.6.0): Supports Ruby 2.5+
# Next version (0.7.0): Will require Ruby 2.7+
# Timeline: Users have clear notice and upgrade path
```

## Ruby Version Lifecycle Reference
- **Ruby 2.5**: EOL March 2021 (32 months ago)
- **Ruby 2.6**: EOL March 2022 (20 months ago)  
- **Ruby 2.7**: Active until March 2024 (4 months remaining)
- **Ruby 3.0**: Active until March 2025
- **Ruby 3.1**: Active until March 2026
- **Ruby 3.2**: Active until March 2027

## Risk Assessment
- **Risk Level**: MEDIUM - Breaking change for EOL Ruby users
- **Security Benefit**: HIGH - Eliminates support for vulnerable Ruby versions
- **Maintenance Benefit**: HIGH - Reduces testing and support complexity
- **User Impact**: LOW - Most users should already be on Ruby 2.7+

## User Communication Strategy

### 1. Clear Error Messages
When users on Ruby 2.5/2.6 try to install:
```bash
gem install asherah
# ERROR: asherah requires Ruby version >= 2.7.0.
# Your current Ruby version is 2.6.10.
```

### 2. Documentation Updates
- Update README with new minimum Ruby version
- Add migration guide for upgrading Ruby versions
- Document rationale for version bump

### 3. Release Notes
Include prominent notice in release notes about breaking change and security rationale.

## Testing & Validation
```bash
# Verify gemspec accepts Ruby 2.7+
ruby -c asherah.gemspec

# Test installation on Ruby 2.7+
rbenv local 2.7.7 && gem build asherah.gemspec && gem install asherah-*.gem

# Test installation failure on Ruby 2.6 (if available)
rbenv local 2.6.10 && gem install asherah-*.gem
# Should fail with clear error message

# Verify RuboCop uses Ruby 2.7 features
bundle exec rubocop --show-cops | grep "TargetRubyVersion"
```

## Production Deployment Notes

### Pre-Deployment
1. **User Survey**: Check usage analytics for Ruby version distribution
2. **Communication**: Announce breaking change in advance
3. **Documentation**: Update all version references

### Post-Deployment
1. **Monitor Issues**: Watch for user reports about Ruby version problems
2. **Support Guidance**: Prepare support team with Ruby upgrade instructions
3. **Ecosystem Check**: Verify compatibility with common Ruby version managers

This change eliminates significant security risks while aligning the project with modern Ruby ecosystem standards.

Fixes issue #12 from REMEDIATION.md - Ruby Version Support Update