### PR TITLE
Fix cross-language tests failing due to invalid Go toolchain

### DIFF
--- a/bin/cross-language-test.sh
+++ b/bin/cross-language-test.sh
@@ -16,6 +16,8 @@ git clone https://github.com/godaddy/asherah.git .
 
 # Install Go packages
 cd $ASHERAH_GO_TEST_DIR
+# Fix invalid toolchain directive
+sed -i.bak '/^toolchain/d' go.mod
 go build ./...
 go mod edit -replace github.com/godaddy/asherah/go/appencryption=../../../go/appencryption
 go mod tidy


### PR DESCRIPTION
## Problem
All PRs are currently failing cross-language tests with errors like:
- "could not import os"
- "could not import cltf"
- "could not import github.com/cucumber/godog"

## Root Cause
The upstream asherah Go repository recently added an invalid toolchain directive to their go.mod file:
```
toolchain go1.24.1
```

Go 1.24 doesn't exist yet, causing the Go environment to fail during test setup.

## Solution
This PR adds a sed command to remove the invalid toolchain directive before building the Go test code. This is a temporary workaround until the upstream repository fixes their go.mod file.

## Testing
After this fix is merged, all pending PRs should have their CI re-run to verify the cross-language tests pass.

## Future Work
Once the upstream asherah repository fixes their go.mod file, this workaround can be removed.