### PR TITLE
Update Go version to 1.24 for cross-language tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.4.0
         with:
-          go-version: 1.23
+          go-version: 1.24
 
       - name: Test Cross-Language
         env:


### PR DESCRIPTION
## Problem
Cross-language tests are failing because the upstream asherah Go repository requires Go 1.24.1 via a toolchain directive in their go.mod file, but our CI uses Go 1.23.

When Go encounters a toolchain directive for a newer version than what's installed, it fails with import errors like "could not import os".

## Solution
Update the GitHub Actions workflow to use Go 1.24 instead of Go 1.23.

## Alternative to PR #58
This is a cleaner solution than PR #58 which removes the toolchain directive. Instead of modifying the upstream code, we update our CI to use the correct Go version.

## Testing
After this is merged, all pending PRs should pass their CI checks without needing the workaround from PR #58.